### PR TITLE
refactor: move instances function closer to IoC definition

### DIFF
--- a/packages/laconia-acceptance-test/src/accept-order.js
+++ b/packages/laconia-acceptance-test/src/accept-order.js
@@ -3,10 +3,6 @@ const laconia = require("@laconia/core");
 const { req, res } = require("@laconia/event").apigateway;
 const KinesisOrderStream = require("./KinesisOrderStream");
 
-const instances = ({ env }) => ({
-  orderStream: new KinesisOrderStream(env.ORDER_STREAM_NAME)
-});
-
 const withCors = next => async (...args) => {
   const response = await next(...args);
   response.headers["Access-Control-Allow-Origin"] = "*";
@@ -29,4 +25,7 @@ const app = async (id, { orderStream }) => {
   return { status: "ok" };
 };
 
+const instances = ({ env }) => ({
+  orderStream: new KinesisOrderStream(env.ORDER_STREAM_NAME)
+})
 exports.handler = laconia(adapter(app)).register(instances);


### PR DESCRIPTION
This pull request demonstrates an example application of [Cohesion Order](https://tidyfirst.substack.com/p/cohesion-order)

Cohesion Order: I also noticed that the function instances should logically sit together when the IoC container is created, which is when the register method is called. Initially, the instances function was at the top of the file, it's moved to the bottom of the file for cohesion.