### PR TITLE
refactor: move app function to top

### DIFF
--- a/packages/laconia-acceptance-test/src/accept-order.js
+++ b/packages/laconia-acceptance-test/src/accept-order.js
@@ -3,6 +3,11 @@ const laconia = require("@laconia/core");
 const { req, res } = require("@laconia/event").apigateway;
 const KinesisOrderStream = require("./KinesisOrderStream");
 
+const app = async (id, { orderStream }) => {
+  await orderStream.send({ eventType: "accepted", orderId: id });
+  return { status: "ok" };
+};
+
 const instances = ({ env }) => ({
   orderStream: new KinesisOrderStream(env.ORDER_STREAM_NAME)
 });
@@ -23,10 +28,5 @@ const adapter = app =>
       return res(err.message, 500);
     }
   });
-
-const app = async (id, { orderStream }) => {
-  await orderStream.send({ eventType: "accepted", orderId: id });
-  return { status: "ok" };
-};
 
 exports.handler = laconia(adapter(app)).register(instances);


### PR DESCRIPTION
This pull request demonstrates an example application of [Reading Order](https://tidyfirst.substack.com/p/reading-order)

Reading Order: I defined what I expected to see first in this file, then opened it up. I expected to see the most important thing, which is the main logic first, and that logic is defined by the app function. That function is currently buried at the bottom of this file, so I pulled it to the top of the file for ease of reading.