### PR TITLE
refactor: move edge case down

### DIFF
--- a/packages/laconia-config/test/SecretsManagerConfigConverter.spec.js
+++ b/packages/laconia-config/test/SecretsManagerConfigConverter.spec.js
@@ -25,25 +25,6 @@ describe("SecretsManagerConfigConverter", () => {
     awsSecretsManager = new AWS.SecretsManager();
   });
 
-  describe("when there is no parameter to be retrieved", () => {
-    beforeEach(() => {
-      secretsManager.getSecretValue.mockImplementation(
-        yields({
-          Parameters: [],
-          InvalidParameters: []
-        })
-      );
-    });
-
-    it("return empty instances", async () => {
-      const configConverter = new SecretsManagerConfigConverter(
-        awsSecretsManager
-      );
-      const instances = await configConverter.convertMultiple({});
-      expect(instances).toEqual({});
-    });
-  });
-
   describe("when single parameter is retrieved", () => {
     let secretsStore;
     let configConverter;
@@ -123,6 +104,25 @@ describe("SecretsManagerConfigConverter", () => {
       );
 
       expect(secretsManager.getSecretValue).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("when there is no parameter to be retrieved", () => {
+    beforeEach(() => {
+      secretsManager.getSecretValue.mockImplementation(
+        yields({
+          Parameters: [],
+          InvalidParameters: []
+        })
+      );
+    });
+
+    it("return empty instances", async () => {
+      const configConverter = new SecretsManagerConfigConverter(
+        awsSecretsManager
+      );
+      const instances = await configConverter.convertMultiple({});
+      expect(instances).toEqual({});
     });
   });
 });


### PR DESCRIPTION
This pull request demonstrates an example application of [Reading Order](https://tidyfirst.substack.com/p/reading-order)

Reading Order: Reading a test file, especially, the describe and it blocks, is a great way to understand the subject's behaviour under test. Understanding the happy path of the subject under test is a great first step, but in this test file, the happy path is currently at the bottom of the test file. This PR reorders the happy path to the top, and the sad path to the bottom.

**Before**:
- when there is no parameter to be retrieved
  - return empty instances

- when single parameter is retrieved
  - should retrieve one secret
  - should retrieve more than one secret

**After**:
- when single parameter is retrieved
  - should retrieve one secret
  - should retrieve more than one secret

- when there is no parameter to be retrieved
  - return empty instances